### PR TITLE
Snnrmse metrics

### DIFF
--- a/catkin_ws/src/pointcloud_to_rangeimage/launch/compression.launch
+++ b/catkin_ws/src/pointcloud_to_rangeimage/launch/compression.launch
@@ -35,6 +35,7 @@
     output="screen"		>
   </node>
 
+  <arg name="ouput_path" default="/catkin_ws/snnrmse_metrics.txt">
   <node
     name="snnrmse"
     pkg="snnrmse"
@@ -42,6 +43,7 @@
     output="screen"		>
     <remap to="/velodyne_points" from="/points2"/> 
     <remap to="/rangeimage_to_pointcloud_node/pointcloud_out" from="/decompressed"/>
+    <param name="output_path" value="$(arg ouput_path)"/>
   </node>
 
   <node

--- a/catkin_ws/src/snnrmse/scripts/snnrmse_node.py
+++ b/catkin_ws/src/snnrmse/scripts/snnrmse_node.py
@@ -70,8 +70,7 @@ class SNNRMSE:
         print("Average Point Number:", metrics["average_point_number"])
         print("======================================")
         
-        save_path = '/catkin_ws/snnrmse_metrics.txt' 
-        with open(save_path, 'a') as file:
+        with open(self.output_path, 'a') as file:
             if metrics["frame"] == 1:
                 file.write(",".join(metrics.keys()))
             file.write("\n")
@@ -81,7 +80,8 @@ class SNNRMSE:
     def __init__(self):
         # initialize ROS node
         rospy.init_node('snnrmse_node', anonymous=False)
-
+        
+        self.output_path = rospy.get_param('~output_path') 
         original_cloud = message_filters.Subscriber('/points2', PointCloud2)
         decompressed_cloud = message_filters.Subscriber('/decompressed', PointCloud2)
 


### PR DESCRIPTION
Creates file and saves metrics, when launching the inference node. Pass an a directory and filename as argument when launching the launch file, e.g. output_path:="/catkin_ws/metrics.txt"